### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubverse`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html). 
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html). 
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: A collection of packages that enables collaborative modeling
     exercises through a unified framework for aggregating, visualizing, and 
     evaluating forecasts. This package is designed to make it easy to install 
     and load multiple 'hubverse' packages in a single step. Learn more at 
-    <https://docs.hubverse.io/en/latest/index.html>.
+    <https://hubverse.io/>.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: A collection of packages that enables collaborative modeling
     exercises through a unified framework for aggregating, visualizing, and 
     evaluating forecasts. This package is designed to make it easy to install 
     and load multiple 'hubverse' packages in a single step. Learn more at 
-    <https://hubverse.io/en/latest/index.html>.
+    <https://docs.hubverse.io/en/latest/index.html>.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(
 
 A collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. This package is designed to make it easy to install and load multiple 'hubverse' packages in a single step.
 
-Learn more at <https://docs.hubverse.io/en/latest/index.html>.
+Learn more at <https://hubverse.io/>.
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# hubverse <a href="https://hubverse.io/en/latest/index.html"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
+# hubverse <a href="https://docs.hubverse.io/en/latest/index.html"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
 
 <!-- badges: start -->
 
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(
 
 A collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. This package is designed to make it easy to install and load multiple 'hubverse' packages in a single step.
 
-Learn more at <https://hubverse.io/en/latest/index.html>.
+Learn more at <https://docs.hubverse.io/en/latest/index.html>.
 
 ## Installation
 
@@ -78,5 +78,5 @@ Please note that the hubEvals package is released with a [Contributor Code of Co
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html)
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -78,5 +78,5 @@ Please note that the hubEvals package is released with a [Contributor Code of Co
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html)
+Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/community/index.html)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# hubverse <a href="https://docs.hubverse.io/en/latest/index.html"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
+# hubverse <a href="https://hubverse.io/"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
 
 <!-- badges: start -->
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# hubverse <a href="https://docs.hubverse.io/en/latest/index.html"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
+# hubverse <a href="https://hubverse.io/"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
 
 <!-- badges: start -->
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ through a unified framework for aggregating, visualizing, and evaluating
 forecasts. This package is designed to make it easy to install and load
 multiple ‘hubverse’ packages in a single step.
 
-Learn more at <https://docs.hubverse.io/en/latest/index.html>.
+Learn more at <https://hubverse.io/>.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# hubverse <a href="https://hubverse.io/en/latest/index.html"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
+# hubverse <a href="https://docs.hubverse.io/en/latest/index.html"><img src="inst/stickers/hubverse-sticker.png" align="right" height="131" alt="hubverse website" /></a>
 
 <!-- badges: start -->
 
@@ -16,7 +16,7 @@ through a unified framework for aggregating, visualizing, and evaluating
 forecasts. This package is designed to make it easy to install and load
 multiple ‘hubverse’ packages in a single step.
 
-Learn more at <https://hubverse.io/en/latest/index.html>.
+Learn more at <https://docs.hubverse.io/en/latest/index.html>.
 
 ## Installation
 
@@ -84,4 +84,4 @@ project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html)
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html)

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://docs.hubverse.io/en/latest/overview/contribute.html)
+Community](https://hubverse.io/community/index.html)

--- a/man/hubverse-package.Rd
+++ b/man/hubverse-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. This package is designed to make it easy to install and load multiple 'hubverse' packages in a single step. Learn more at \url{https://hubverse.io/en/latest/index.html}.
+A collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. This package is designed to make it easy to install and load multiple 'hubverse' packages in a single step. Learn more at \url{https://docs.hubverse.io/en/latest/index.html}.
 }
 \seealso{
 Useful links:

--- a/man/hubverse-package.Rd
+++ b/man/hubverse-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. This package is designed to make it easy to install and load multiple 'hubverse' packages in a single step. Learn more at \url{https://docs.hubverse.io/en/latest/index.html}.
+A collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. This package is designed to make it easy to install and load multiple 'hubverse' packages in a single step. Learn more at \url{https://hubverse.io}.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.