### PR TITLE
Updating oracle-output expectations

### DIFF
--- a/vignettes/hubverse_ms_vignette.Rmd
+++ b/vignettes/hubverse_ms_vignette.Rmd
@@ -148,6 +148,7 @@ Accessing target data follows a similar pattern to accessing model output data. 
 
 ```{r}
 ts_data_con <- hubData::connect_target_timeseries(hub_path)
+ts_data_con
 ```
 
 Next, we filter the target data to the location and time period of interest. In this case, we are interested in the state of Texas (FIPS code 48) and the 2024-2025 respiratory virus season, which runs from September 23, 2024 to May 1, 2024. We also filter to the most recent `as_of` date to ensure we are using the latest available data. The `as_of` date is a metadata field that indicates when the target data was last updated.
@@ -260,6 +261,7 @@ The FluSight hub also stores oracle output data in the cloud, and we can access 
 
 ```{r}
 oo_data_con <- hubData::connect_target_oracle_output(hub_path)
+oo_data_con
 ```
 
 Once we have a connection to the data, we can query it for the data of interest. In this case, we want to filter the oracle output data to the same location and time period as the model output data, and for the same target. We also filter to the maximum `as_of` date to ensure we are using the latest available data. The `reference_date`, which is present in model output data but not in oracle data, is computed as the `target_end_date` minus the `horizon` in weeks, and used to filter the oracle output data to the same reference dates as the model output data. 

--- a/vignettes/hubverse_ms_vignette.Rmd
+++ b/vignettes/hubverse_ms_vignette.Rmd
@@ -264,23 +264,21 @@ oo_data_con <- hubData::connect_target_oracle_output(hub_path)
 oo_data_con
 ```
 
-Once we have a connection to the data, we can query it for the data of interest. In this case, we want to filter the oracle output data to the same location and time period as the model output data, and for the same target. We also filter to the maximum `as_of` date to ensure we are using the latest available data. The `reference_date`, which is present in model output data but not in oracle data, is computed as the `target_end_date` minus the `horizon` in weeks, and used to filter the oracle output data to the same reference dates as the model output data. 
+Once we have a connection to the data, we can query it for the data of interest. In this case, we want to filter the oracle output data to the same location and time period as the model output data, and for the same target.  
 
 ```{r}
 oracle_output <- oo_data_con |>
-  arrow::to_duckdb() |>
-  mutate(reference_date = target_end_date - horizon * 7L) |>
   filter(
-    reference_date %in% reference_dates,
     target == "wk inc flu hosp",
     output_type == "quantile",
-    location == "48", ## FIPS code for Texas
-    horizon > -1,
-    as_of == max(as_of)
+    location == "48" ## FIPS code for Texas
   ) |>
-  select(target, reference_date, target_end_date, location, horizon, output_type, output_type_id, oracle_value) |>
-  arrange(reference_date, horizon) |>
-  collect()
+  select(target, target_end_date, location, output_type, output_type_id, oracle_value) |>
+  distinct() |>
+  arrange(target_end_date) |>
+  collect() 
+
+oracle_output
 ```
 
 
@@ -288,14 +286,7 @@ Note that some hubs may not store oracle output data but it can [generally be ge
 
 ```{r, eval=FALSE}
 target_data |>
-  select(target_end_date, location, observation) |>
-  rename(
-    target_end_date = date,
-    oracle_value = observation
-  ) |>
-  tidyr::crossing(horizon = 0:3) |>
-  mutate(reference_date = target_end_date - horizon * 7L) |>
-  filter(reference_date %in% reference_dates)
+  select(target_end_date, location, observation)
 ```
 
 Now that we have our oracle (observed) data in a format that can be combined with model output data, we can move on to evaluating it. In this example, we compute and show results for the average weighted interval score (WIS) with its associated decomposition into overprediction, underprediction, and dispersion penalties, the 50% and 90% prediction interval coverage rates, and the absolute error computed on the median prediction[@bracher_evaluating_2021]. To do this, we use the `hubEvals::score_model_out()` function which scores model outputs against observed data. Further information is available in the help page of the `hubEvals` package.


### PR DESCRIPTION
I found it easier to just open another PR with a few more suggestions, related the discussions we've been having the [RFC](https://github.com/reichlab/decisions/pull/31) where we're thinking through the `target-data.yml` file and it's documentation.

To make the vignette with some of the discussions we've been having, this PR:
- Removes any mention of a `horizon` column and abandons creating the additional `reference_date` in the `oracle-output` collected data.
- It also removes filtering for `as_of` column in `oracle-output` data. 

## Outstanding external actions.

Firstly, we need to decide once and for all if this column should even be allowed in `oracle-output data`. If not, we should remove it from any hubs, especially those we're using for a demo. If not though, as I understand `oracle-data` generally have only have a single version of the data. If so then perhaps we should be enforcing it and consequently think about what it means for validation/expectations for that column. It could even be useful as a provence record, linking rows in `oracle-output` back to the `time-series` dataset where actual versioned data are stored. 

We  should also remove the `horizon` column in the `oracle-output` data in vthe hub to ensure we only store the minimum observable_unit subset of target model output data. 